### PR TITLE
Add pre-allocated fill_array subroutines to avoid overhead

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -1,5 +1,5 @@
 name = "rndgen-fortran"
-version = "1.0.5"
+version = "1.0.6"
 license = "GNU General Public License v3.0"
 author = "Wesley Cota"
 maintainer = "wlcota@gmail.com"

--- a/src/rndgen.f90
+++ b/src/rndgen.f90
@@ -84,9 +84,9 @@ module rndgen_mod
       procedure, private :: rnd_array_int_i4
       
       generic :: fill_array => fill_rnd_array_rnd, fill_rnd_array_real, fill_rnd_array_int_i4
-      procedure :: fill_rnd_array_rnd
-      procedure :: fill_rnd_array_real
-      procedure :: fill_rnd_array_int_i4
+      procedure, private :: fill_rnd_array_rnd
+      procedure, private :: fill_rnd_array_real
+      procedure, private :: fill_rnd_array_int_i4
       
 
    end type

--- a/src/rndgen.f90
+++ b/src/rndgen.f90
@@ -82,6 +82,12 @@ module rndgen_mod
       procedure, private :: rnd_array_rnd
       procedure, private :: rnd_array_real
       procedure, private :: rnd_array_int_i4
+      
+      generic :: fill_array => fill_rnd_array_rnd, fill_rnd_array_real, fill_rnd_array_int_i4
+      procedure :: fill_rnd_array_rnd
+      procedure :: fill_rnd_array_real
+      procedure :: fill_rnd_array_int_i4
+      
 
    end type
 
@@ -352,4 +358,33 @@ contains
 
  end function rnd_array_int_i8
 
+!> Fills an array with real numbers in the range [0, 1)
+ subroutine fill_rnd_array_rnd( gen , arr )
+      class(rndgen) , intent(in) :: gen
+      real(kind=dp) , intent(out) :: arr(:)
+      integer(kind=i4) :: i
+      do i = 1, size(arr)
+        arr(i) = gen%rnd()
+      end do
+ end subroutine fill_rnd_array_rnd
+!> Fills an array with real numbers in the range [r1, r2)
+ subroutine fill_rnd_array_real( gen , arr , r1 , r2 )
+      class(rndgen) , intent(in) :: gen
+      real(kind=dp) , intent(out) :: arr(:)
+      real(kind=dp) , intent(in) :: r1 , r2
+      integer(kind=i4) :: i
+      do i = 1, size(arr)
+        arr(i) = gen%real( r1 , r2 )
+      end do
+ end subroutine fill_rnd_array_real
+!> Fills an array with integer numbers in the range [i1, i2)
+ subroutine fill_rnd_array_int_i4( gen , arr , i1 , i2 )
+      class(rndgen) , intent(in) :: gen
+      integer(kind=i4) , intent(out) :: arr(:)
+      integer(kind=i4) , intent(in) :: i1 , i2
+      integer(kind=i4) :: i
+      do i = 1, size(arr)
+        arr(i) = gen%int( i1 , i2 )
+      end do
+ end subroutine fill_rnd_array_int_i4
 end module


### PR DESCRIPTION
Add fill_array generic interface for zero-allocation loops

Em aplicações que repetidamente precisam gerar arrays de mesmo tamanho, a rotina rnd_array causa um overhead por ter que alocar dinamicamente um array, gerar n números aleatórios e copiar a variável interna da função na variável externa do programa. Para evitar gargalos, adicionei a interface genérica fill_array, com sub-rotinas para preencher um array externo com números gerados. Isto evita os processos internos de alocar e desalocar memória e copiar variáveis, que podem virar gargalos em rotinas longas.